### PR TITLE
adds uuid for JSON-RPC bind requests

### DIFF
--- a/lib/multibinder.rb
+++ b/lib/multibinder.rb
@@ -1,5 +1,6 @@
 require 'multibinder/version'
 require 'json'
+require 'securerandom'
 
 module MultiBinder
   def self.bind(address, port, options={})
@@ -11,6 +12,7 @@ module MultiBinder
     binder.sendmsg JSON.dump({
       :jsonrpc => '2.0',
       :method => 'bind',
+      :id => SecureRandom.uuid,
       :params => [{
         :address => address,
         :port => port,


### PR DESCRIPTION
First of all, thanks for the multibinder. The idea is just great. 

PR Details:
* JSON-RPC 2.0 requests must contain an ID, otherwise they are treated as notifications.
* adds SecureRandom UUID id to every bind request