### PR TITLE
Require the socket library in multibinder.rb

### DIFF
--- a/lib/multibinder.rb
+++ b/lib/multibinder.rb
@@ -1,5 +1,6 @@
 require 'multibinder/version'
 require 'json'
+require 'socket'
 
 module MultiBinder
   def self.bind(address, port, options={})


### PR DESCRIPTION
Right now it's required in the binstubs but not in the lib. It's probably good to require here since this file uses `UNIXSocket`.