### PR TITLE
Require socket and fcntl in multibinder.rb

### DIFF
--- a/lib/multibinder.rb
+++ b/lib/multibinder.rb
@@ -1,6 +1,8 @@
 require 'multibinder/version'
 require 'json'
 require 'securerandom'
+require 'socket'
+require 'fcntl'
 
 module MultiBinder
   def self.bind(address, port, options={})


### PR DESCRIPTION
Follows up on https://github.com/github/multibinder/issues/3 and the original fix in https://github.com/github/multibinder/pull/4 to include both `socket` and `fcntl` in `lib/multibinder.rb` rather than requiring each script to include them.