### PR TITLE
Allow .mb extension in addition to .erb

### DIFF
--- a/bin/multibinder-haproxy-erb
+++ b/bin/multibinder-haproxy-erb
@@ -13,8 +13,8 @@ haproxy_call = ARGV
 abort 'multibinder-haproxy expects a configuration file to be passed to haproxy' if haproxy_call.index('-f').nil?
 config_file_index = haproxy_call.index('-f') + 1
 haproxy_erb = haproxy_call[config_file_index]
-abort 'Config file must end with .erb' unless haproxy_erb.end_with? '.erb'
-haproxy_cfg = haproxy_erb.sub('.erb', '')
+abort 'Config file must end with .erb' unless haproxy_erb.end_with? '.erb' or haproxy_erb.end_width? '.mb'
+haproxy_cfg = haproxy_erb.sub(/\.(erb|mb)$/, '')
 haproxy_call[config_file_index] = haproxy_cfg
 
 def bind_tcp(ip, port)


### PR DESCRIPTION
This allows multibinder's haproxy config files to end in `.mb` or `.erb`. This allows things to use distinct extensions in cases where there there's a previous (erb) templating step.

/cc @theojulienne 