### PR TITLE
Wait for haproxy pidfile to be created to avoid race condition.

### DIFF
--- a/bin/multibinder-haproxy-wrapper
+++ b/bin/multibinder-haproxy-wrapper
@@ -39,7 +39,10 @@ Signal.trap("USR2") do
 
   # wait a while for the pid file to change. after a while, give up and unblock reloads
   for i in 0..20
-    break if File.read($PID_FILE) != old_pids
+    begin
+      break if File.read($PID_FILE) != old_pids
+    rescue Errno::ENOENT
+    end
     sleep 1
   end
 end

--- a/lib/multibinder/version.rb
+++ b/lib/multibinder/version.rb
@@ -1,3 +1,3 @@
 module MultiBinder
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end


### PR DESCRIPTION
Over in https://github.com/github/multibinder/issues/13 it was reported that sometimes this read would fail in a gap where [haproxy unlinks the pid file momentarily](https://github.com/haproxy/haproxy/blob/master/src/haproxy.c#L1902-L1903). Since this is only momentary, it should suffice to simply allow this to fail during our polling interval and retry the next time.

Fixes https://github.com/github/multibinder/issues/13