### PR TITLE
Fix haproxy wrapper to keep FDs around until exec.

### DIFF
--- a/bin/multibinder-haproxy-erb
+++ b/bin/multibinder-haproxy-erb
@@ -17,10 +17,13 @@ abort 'Config file must end with .erb or .mb' unless haproxy_erb.end_with? '.erb
 haproxy_cfg = haproxy_erb.sub(/\.(erb|mb)$/, '')
 haproxy_call[config_file_index] = haproxy_cfg
 
+$all_sockets = []
+
 def bind_tcp(ip, port)
   if ENV['MULTIBINDER_SOCK'] && !ENV['MULTIBINDER_SOCK'].empty?
     # if we have multibinder, use it to reuse our binds safely
     server = MultiBinder.bind ip, port, { :backlog => 10240 }
+    $all_sockets.push server # keep a copy while we're running so we don't GC the file descriptors by accident
     "fd@#{server.fileno}"
   else
     # otherwise resort to the old fashioned binds with downtime/packet loss

--- a/test/test-haproxy.sh
+++ b/test/test-haproxy.sh
@@ -27,3 +27,25 @@ begin_test "haproxy runs with multibinder"
   curl --max-time 5 http://localhost:$(offset_port $TEST_PORT)/ | grep -q 'Request forbidden'
 )
 end_test
+
+begin_test "haproxy can bind to large numbers of file descriptors"
+(
+  setup
+
+  export TEMPDIR
+
+  echo >$TEMPDIR/haproxy-many-fds.cfg.erb
+
+  for i in $(seq 1000); do
+    echo "  bind <%= bind_tcp('127.0.0.1', $((TEST_PORT + $i))) %>" >>$TEMPDIR/haproxy-many-fds.cfg.erb
+  done
+
+  bundle exec env MULTIBINDER_SOCK=${TEMPDIR}/multibinder.sock ruby bin/multibinder-haproxy-erb -f $TEMPDIR/haproxy-many-fds.cfg.erb --erb-write-only
+
+  if grep 'bind fd@' $TEMPDIR/haproxy-many-fds.cfg | sort | uniq -d | grep -q 'bind fd@'; then
+  	echo 'Expected unique FDs, but found duplicates:'
+  	cat $TEMPDIR/haproxy-many-fds.cfg
+  	exit 1
+  fi
+)
+end_test


### PR DESCRIPTION
This PR keeps around a copy of ruby objects containing file descriptors in the haproxy wrapper script to ensure that the ruby GC doesn't throw them away before the exec.

Fixes https://github.com/github/multibinder/issues/11